### PR TITLE
Fix headers inside FAQ

### DIFF
--- a/devent.toml
+++ b/devent.toml
@@ -109,17 +109,17 @@ Yes! Please reach out to camp@ipfs.io if you’d like to discuss listing it on t
 It has been almost three years since our last in-person IPFS Camp! We’re excited to see everyone’s faces soon! While COVID-19’s most acute days are past, we are taking precautions to help limit spread and protect the health of our IPFS and global communities.
 As of September 2022, Portugal has lifted entry requirements related to COVID-19.
 
-<b>Rapid Antigen Testing</b>
+RAPID ANTIGEN TESTING
 IPFS Camp will host a 100% free mobile testing site at the entrance to Convento do Beato where every attendee will be required to take an antigen rapid test prior to picking up their badge (regardless of vaccination status).
 Tests will be self administered, and results take about 15 minutes to process. 
 
-<b>Masks</b>
+MASKS
 IPFS Camp will have plenty of masks and hand sanitizer available at the entrance and key locations within the venue each day. We recommend wearing a mask indoors.
 
-<b>Meals</b>
+MEALS
 Lunch and dinner will primarily take place in well-ventilated areas or outdoors.
 
-<b>Illness</b>
+ILLNESS
 If you feel sick or have tested positive, stay at home. If at any point during your visit to IPFS Camp you feel sick, please visit our onsite testing center to take a follow-up test. Whether or not you test positive for COVID-19, if you have symptoms that mirror any other communicable disease (i.e. flu, cold, etc.) we ask that you do not visit in-person venues until your symptoms subside. 
 
 If you must cut short your visit to IPFS Camp due to illness, you may email camp@ipfs.io for a ticket refund. We will be sorry to see you go but thankful for your part in keeping the community healthy.


### PR DESCRIPTION
The HTML tags `<b></b>` don't render correctly here, so I switched those headers to all caps. (FYI @nikipdia.)