### PR TITLE
Update footer links

### DIFF
--- a/devent.toml
+++ b/devent.toml
@@ -186,19 +186,3 @@ image = "speakers/george-lory.jpg"
 description="""
 All scheduled events are [optional](/#faq).
 """
-
-# this is a footer section, with any footer links you may want.
-# there are three sections: links (general), legal (policy + terms), and social.
-[footer]
-
-[footer.links]
-"Protocol Labs" = "https://protocol.ai/"
-"Event Github" = "https://github.com/protocol/labweek-2022"
-
-[footer.legal]
-"Privacy Policy" = "#"
-"Terms & Conditions" = "#"
-
-[footer.social]
-twitter = "ipfs"
-github = "ipfs"

--- a/website/components/footer.js
+++ b/website/components/footer.js
@@ -44,20 +44,20 @@ export default function Footer({ config }) {
 						<div>
 							<h3 className="text-white text-h5 mb-4">Related Projects</h3>
 							<nav>
-								<Link name="IPFS" link="#" />
-								<Link name="IPFS Cluster" link="#" />
-								<Link name="libp2p" link="#" />
-								<Link name="IPLD" link="#" />
-								<Link name="Multiformats" link="#" />
+								<Link name="IPFS" link="https://ipfs.tech/" />
+								<Link name="IPFS Cluster" link="https://ipfscluster.io/" />
+								<Link name="libp2p" link="https://libp2p.io/" />
+								<Link name="IPLD" link="https://ipld.io/" />
+								<Link name="Multiformats" link="https://multiformats.io/" />
 							</nav>
 						</div>
 						<div>
 							<h3 className="text-white text-h5 mb-4">Stay Updated</h3>
 							<nav>
-								<Link name="@IPFS" link="#" />
-								<Link name="IPFS Blog" link="#" />
-								<Link name="Forum" link="#" />
-								<Link name="Discord/Matrix/Slack" link="#" />
+								<Link name="@IPFS" link="https://twitter.com/ipfs" />
+								<Link name="IPFS Blog" link="https://blog.ipfs.tech/" />
+								<Link name="Forum" link="https://discuss.ipfs.tech/" />
+								<Link name="Discord/Matrix/Slack" link="https://docs.ipfs.tech/community/chat/" />
 							</nav>
 						</div>
 					</div>

--- a/website/components/footer.js
+++ b/website/components/footer.js
@@ -33,32 +33,31 @@ export default function Footer({ config }) {
 							<h3 className="text-white text-h5 mb-4">IPFS Camp</h3>
 							<nav>
 								<Link name="Tracks" link="#" />
-								<Link name="IPFS CAMP" link="" />
-								<Link name="Tracks" link="" />
 								<Link name="Tickets" link="" />
 								<Link name="Schedule" link="" />
-								<Link name="Speakers" link="" />
-								<Link name="FAQAbout IPFS" link="" />
-								<Link name="Privacy Policy" link="" />
+								<Link name="Speakers & Facilitators" link="" />
+								<Link name="FAQ" link="" />
+								<Link name="COVID-19 Policy" link="" />
+								<Link name="Code of Conduct" link="" />
 							</nav>
 						</div>
 						<div>
 							<h3 className="text-white text-h5 mb-4">Related Projects</h3>
 							<nav>
 								<Link name="IPFS" link="#" />
-								<Link name="IPFS CLUSTER" link="#" />
-								<Link name="LIBP2P" link="#" />
+								<Link name="IPFS Cluster" link="#" />
+								<Link name="libp2p" link="#" />
 								<Link name="IPLD" link="#" />
-								<Link name="MULTIFORMATS" link="#" />
+								<Link name="Multiformats" link="#" />
 							</nav>
 						</div>
 						<div>
 							<h3 className="text-white text-h5 mb-4">Stay Updated</h3>
 							<nav>
-								<Link name="Mailing List" link="#" />
-								<Link name="@IPFSBOT" link="#" />
+								<Link name="@IPFS" link="#" />
 								<Link name="IPFS Blog" link="#" />
-								<Link name="Join IRC channel" link="#" />
+								<Link name="Forum" link="#" />
+								<Link name="Discord/Matrix/Slack" link="#" />
 							</nav>
 						</div>
 					</div>


### PR DESCRIPTION
- This PR updates link text & link targets in the footer (in `footer.js`), except for the link targets in the left "IPFS Camp" column.
- It also removes the footer section from `devent.toml`, as I believe they are not used in this website (@tbenbow please confirm).

@tbenbow can you advise on what the format for linking to inline sections would be (lines 35-41)?