### PR TITLE
Sponsorship text update

### DIFF
--- a/devent.toml
+++ b/devent.toml
@@ -20,6 +20,10 @@ description="""
 Join us for talks, workshops, discussion circles, hacking time, and more, all focused on celebrating and advancing IPFS. October 28-30, Lisbon, Portugal
 """
 
+description="""
+Please reach out to camp@ipfs.io if you would like to sponsor IPFS Camp 2022.
+"""
+
 
 # a link to the devent website (what domain do you expect to use?) also used for canonical tag
 link="https://2022.ipfs.camp/"

--- a/devent.toml
+++ b/devent.toml
@@ -18,9 +18,7 @@ IPFS Camp 2022  is a gathering for the entire  IPFS community: devs, operators, 
 
 description="""
 Join us for talks, workshops, discussion circles, hacking time, and more, all focused on celebrating and advancing IPFS. October 28-30, Lisbon, Portugal
-"""
 
-description="""
 Please reach out to camp@ipfs.io if you would like to sponsor IPFS Camp 2022.
 """
 


### PR DESCRIPTION
Added Sponsorship text to first section:
"Please reach out to camp@ipfs.io if you would like to sponsor IPFS Camp 2022."