### PR TITLE
Change ticket link

### DIFF
--- a/devent.toml
+++ b/devent.toml
@@ -27,9 +27,6 @@ link="https://2022.ipfs.camp/"
 # a link to get tickets
 ticketLink="#tickets"
 
-# a link to RSVP for the event
-# rsvpLink="#tickets"
-
 # a link to apply to speak for the event
 speakLink="https://airtable.com/shrOxmXUqwojf0Bjj"
 


### PR DESCRIPTION
Changes the "Get Tickets" button link from the general tickets Luma page to the full #tickets section, with 5 options.