### PR TITLE
update content-routing schedule for presenters

### DIFF
--- a/events/content-routing.toml
+++ b/events/content-routing.toml
@@ -103,7 +103,7 @@ description="How Estuary keeps content available today and in the future"
 [[timeslots]]
 startTime="12:45"
 speakers=["@thibmeu"]
-title="Where's bafy: gateway perspective on content routing"
+title="Experience Content Routing from a Gateway Perspective"
 description="Content routing from a Gateway's perspective"
 
 [[timeslots]]

--- a/events/content-routing.toml
+++ b/events/content-routing.toml
@@ -104,7 +104,7 @@ description="How Estuary keeps content available today and in the future"
 startTime="12:45"
 speakers=["@thibmeu"]
 title="Experience Content Routing from a Gateway Perspective"
-description="Content routing from a Gateway's perspective"
+description="Discover the challenges that an IPFS Gateway faces to route content."
 
 [[timeslots]]
 startTime="13:00"

--- a/events/content-routing.toml
+++ b/events/content-routing.toml
@@ -80,31 +80,31 @@ speakers=["@ischasny"]
 title="Workshop: Indexed content routing"
 description="Explore Kubo delegated routing to publish and query indexers"
 
+
 [[timeslots]]
 startTime="11:45"
-speakers=["@thibmeu"]
-title="Where's bafy: gateway perspective on content routing"
-description="Content routing from a Gateway's perspective"
-
+speakers=["@guseggert", "@willscott", "@alanshaw"]
+title="Panel: the future of content routing"
+description="How could inter-planetary content routing continue to evolve going forward?"
 
 [[timeslots]]
-startTime="12:00"
+startTime="12:15"
 speakers=[]
 title="Break"
 description=""
 
 [[timeslots]]
-startTime="12:15"
+startTime="12:30"
 speakers=["@elijaharita"]
 title="Keeping Estuary Content Available"
 description="How Estuary keeps content available today and in the future"
 
 
 [[timeslots]]
-startTime="12:30"
-speakers=["@guseggert", "@willscott", "@alanshaw"]
-title="Panel: the future of content routing"
-description="How could inter-planetary content routing continue to evolve going forward?"
+startTime="12:45"
+speakers=["@thibmeu"]
+title="Where's bafy: gateway perspective on content routing"
+description="Content routing from a Gateway's perspective"
 
 [[timeslots]]
 startTime="13:00"


### PR DESCRIPTION
@thibmeu was double-scheduled with his talk for the `IPFS Operators and Enterprise` track. this shuffles things a bit to make it possible for everyone to make their talks :)