### PR TITLE
Modify event name

### DIFF
--- a/events/ipfs-project-expo.toml
+++ b/events/ipfs-project-expo.toml
@@ -1,5 +1,5 @@
 # the name of your track or event
-name = "IPFS Project Fair"
+name = "IPFS Project Expo"
 
 # the github handle of the directly responsible individual for this event
 # (this person will coordinate with devent organizers)


### PR DESCRIPTION
This PR is for renaming the event `IPFS Project Fair` to `IPFS Project Expo`.